### PR TITLE
Populate Item URI

### DIFF
--- a/boot-ops-core/src/main/java/com/github/kirksc1/bootops/core/BaseItemStreamCommand.java
+++ b/boot-ops-core/src/main/java/com/github/kirksc1/bootops/core/BaseItemStreamCommand.java
@@ -109,6 +109,7 @@ public abstract class BaseItemStreamCommand extends ItemStreamCommand {
             }
 
             if (this.filter.test(item)) {
+                item.setUri(uri);
                 retVal = execute(item, parameters, new DefaultItemContext());
                 publisher.publishEvent(new ItemCompletedEvent(this, item));
             } else {

--- a/boot-ops-core/src/test/java/com/github/kirksc1/bootops/core/BaseItemStreamCommandTest.java
+++ b/boot-ops-core/src/test/java/com/github/kirksc1/bootops/core/BaseItemStreamCommandTest.java
@@ -97,6 +97,7 @@ class BaseItemStreamCommandTest {
         verify(parser, times(1)).parse(same(inputStream));
         verify(publisher, times(1)).publishEvent(any(ItemCompletedEvent.class));
         verify(publisher, times(0)).publishEvent(any(BootOpsExceptionEvent.class));
+        verify(item, times(1)).setUri(same(uri));
 
         List<Item> items = command.getItems();
         assertEquals(1, items.size());


### PR DESCRIPTION
- Closes #37 enables event listeners to understand where the item manifest file is located